### PR TITLE
New method to check randomly the spectrum references

### DIFF
--- a/src/main/java/uk/ac/ebi/pride/utilities/data/controller/cache/strategy/MzIdentMLCachingStrategy.java
+++ b/src/main/java/uk/ac/ebi/pride/utilities/data/controller/cache/strategy/MzIdentMLCachingStrategy.java
@@ -54,8 +54,8 @@ public class MzIdentMLCachingStrategy extends AbstractCachingStrategy {
          * */
         try {
             if (proteinGroupPresent) {
-                cacheSpectrumIds(unmarshaller);
                 cacheProteinGroups(unmarshaller);
+                cacheSpectrumIds(unmarshaller);
             } else {
                 cachePrescanIdMaps(unmarshaller);
             }

--- a/src/main/java/uk/ac/ebi/pride/utilities/data/controller/impl/ControllerImpl/MzTabControllerImpl.java
+++ b/src/main/java/uk/ac/ebi/pride/utilities/data/controller/impl/ControllerImpl/MzTabControllerImpl.java
@@ -545,6 +545,8 @@ public class MzTabControllerImpl extends ReferencedIdentificationController{
         BufferedReader reader = null;
         int quantitationCount = 0;
         int identificationCount = 0;
+        if(!file.getName().toLowerCase().endsWith(Constants.MZTAB_EXT))
+            return false;
 
         /**
          * To validate  the mzTab if is supported or not we will read the header line by line until the type appear

--- a/src/main/java/uk/ac/ebi/pride/utilities/data/controller/impl/ControllerImpl/ReferencedIdentificationController.java
+++ b/src/main/java/uk/ac/ebi/pride/utilities/data/controller/impl/ControllerImpl/ReferencedIdentificationController.java
@@ -10,6 +10,7 @@ import uk.ac.ebi.pride.utilities.data.controller.cache.CacheEntry;
 import uk.ac.ebi.pride.utilities.data.core.*;
 import uk.ac.ebi.pride.utilities.data.utils.Constants;
 import uk.ac.ebi.pride.utilities.data.utils.MzIdentMLUtils;
+import uk.ac.ebi.pride.utilities.mol.MoleculeUtilities;
 import uk.ac.ebi.pride.utilities.util.Tuple;
 
 import java.io.File;
@@ -562,6 +563,44 @@ public abstract class ReferencedIdentificationController extends CachedDataAcces
     @Override
     public boolean hasProteinAmbiguityGroup() {
         return super.getProteinAmbiguityGroupIds().size() > 0;
+    }
+
+    /**
+     * This function check randomly if the spectra is well referenced for a couple of spectra
+     * for that it is using the the number of Spectra to be check.
+     * @param numberSpectra the number of spectra to be checked
+     * @return boolean if all the reference as fine
+     */
+    public boolean checkRandomSpectraByDeltaMassThreshold(int numberSpectra, Double deltaThreshold){
+        Collection<Comparable> proteinIds = getProteinIds();
+        List<Comparable> listIds = new ArrayList<Comparable>(proteinIds);
+
+        if(!hasSpectrum())
+            return false;
+
+        int i = 0;
+        while (i < numberSpectra){
+            int randomNum = (int)(Math.random() * listIds.size());
+            Comparable proteinId = listIds.get(randomNum);
+            Protein protein = getProteinById(proteinId);
+            int randomNumPep = (int)(Math.random() * protein.getPeptides().size());
+            Peptide peptide = protein.getPeptides().get(randomNumPep);
+            Spectrum spectrum = getSpectrumById(peptide.getSpectrumIdentification().getId());
+            Double mz =  DataAccessUtilities.getPrecursorMz(spectrum);
+            Integer charge = DataAccessUtilities.getPrecursorChargeParamGroup(spectrum);
+            List<Double> ptmMasses = new ArrayList<Double>();
+            for (Modification mod : peptide.getModifications()) {
+                List<Double> monoMasses = mod.getMonoisotopicMassDelta();
+                if (monoMasses != null && !monoMasses.isEmpty())
+                    ptmMasses.add(monoMasses.get(0));
+            }
+            Double delta = MoleculeUtilities.calculateDeltaMz(peptide.getSequence(), mz, charge, ptmMasses);
+            if(delta > deltaThreshold)
+                return false;
+            i++;
+        }
+        return true;
+
     }
 
 

--- a/src/test/java/uk/ac/ebi/pride/utilities/data/controller/impl/ControllerImpl/MzIdentMLIgnoreProteinInferenceTest.java
+++ b/src/test/java/uk/ac/ebi/pride/utilities/data/controller/impl/ControllerImpl/MzIdentMLIgnoreProteinInferenceTest.java
@@ -123,7 +123,7 @@ public class MzIdentMLIgnoreProteinInferenceTest {
     public void testGetIdentificationIDs() throws DataAccessException {
         List<Comparable> identifications = new ArrayList<Comparable>(mzIdentMlController.getProteinIds());
         assertTrue("The numer of Identification should be 2", identifications.size()==2044);
-        assertEquals("The id of the first identification should be PDH_psu|NC_LIV_020800_0",identifications.get(0).toString(),"DBSeq_1_Rnd2psu|NC_LIV_100160");
+        assertEquals("The id of the first identification should be DBSeq_1_psu|NC_LIV_102740",identifications.get(0).toString(),"DBSeq_1_psu|NC_LIV_102740");
     }
 
 }

--- a/src/test/java/uk/ac/ebi/pride/utilities/data/controller/impl/ControllerImpl/MzIdentMlMSControllerImplTest.java
+++ b/src/test/java/uk/ac/ebi/pride/utilities/data/controller/impl/ControllerImpl/MzIdentMlMSControllerImplTest.java
@@ -1,6 +1,7 @@
 package uk.ac.ebi.pride.utilities.data.controller.impl.ControllerImpl;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import uk.ac.ebi.pride.utilities.data.core.Spectrum;
@@ -29,6 +30,12 @@ public class MzIdentMlMSControllerImplTest {
         }
         File inputFile = new File(url.toURI());
         mzIdentMlController = new MzIdentMLControllerImpl(inputFile, true);
+        url = MzIdentMlControllerImplTest.class.getClassLoader().getResource("small.mgf");
+        File filems = new File(url != null ? url.getFile() : null != null ? url != null ? url.getFile() : null : null);
+        List<File> fileList = new ArrayList<File>();
+        fileList.add(filems);
+        mzIdentMlController.addMSController(fileList);
+
     }
 
     @After
@@ -39,14 +46,16 @@ public class MzIdentMlMSControllerImplTest {
 
     @Test
     public void addMSController() throws Exception {
-        URL url = MzIdentMlControllerImplTest.class.getClassLoader().getResource("small.mgf");
-        File filems = new File(url != null ? url.getFile() : null != null ? url != null ? url.getFile() : null : null);
-        List<File> fileList = new ArrayList<File>();
-        fileList.add(filems);
-        mzIdentMlController.addMSController(fileList);
         Spectrum spectrum = mzIdentMlController.getSpectrumById("730!SD_1");
         assertTrue("There should be 60 peaks", spectrum.getIntensityBinaryDataArray().getDoubleArray().length == 60);
     }
+
+    @Test
+    public void checkReferencedSpectra(){
+        boolean status = mzIdentMlController.checkRandomSpectraByDeltaMassThreshold(10, 2.0);
+        Assert.assertTrue(status);
+    }
+
 
 
 }

--- a/src/test/java/uk/ac/ebi/pride/utilities/data/controller/impl/ControllerImpl/MzTabControllerImplTest.java
+++ b/src/test/java/uk/ac/ebi/pride/utilities/data/controller/impl/ControllerImpl/MzTabControllerImplTest.java
@@ -69,7 +69,7 @@ public class MzTabControllerImplTest {
         Collection<Comparable> ids = mzTabController.getProteinIds();
         assertTrue("The number of Proteins is", ids.size() == 1249);
         Protein protein = mzTabController.getProteinById(ids.iterator().next());
-        assertTrue("The first protein has ", protein.getPeptides().size() == 3);
+        assertTrue("The first protein has ", protein.getPeptides().size() == 2);
     }
 
     @Test


### PR DESCRIPTION
@Tobias-Ternent :
 This pull request is to integrate the check for each file a set of spectra for an specific delta mass. This is 
 to solve the issue we have in the pipeline. We should be able to run this easily in the pipeline by using 
 this option from the example tests:

```java
 boolean status = mzIdentMlController.checkRandomSpectraByDeltaMassThreshold(10, 2.0);
```
if is false then we have an annotation error. 

Regards